### PR TITLE
Fix/ci-environment-variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      GITHUB_ID: ${{ secrets.GITHUB_ID }}
+      GITHUB_SECRET: ${{ secrets.GITHUB_SECRET }}
+      NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+      NEXTAUTH_URL: http://localhost:3000
+
     steps:
     - uses: actions/checkout@v3
 

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,20 +1,27 @@
-import NextAuth from "next-auth"
+import NextAuth, { NextAuthOptions } from "next-auth"
 import GithubProvider from "next-auth/providers/github"
 
-if (!process.env.GITHUB_ID || !process.env.GITHUB_SECRET) {
-  throw new Error('Missing GitHub OAuth credentials');
-}
-
-const handler = NextAuth({
+const authOptions: NextAuthOptions = {
   providers: [
     GithubProvider({
-      clientId: process.env.GITHUB_ID,
-      clientSecret: process.env.GITHUB_SECRET,
+      clientId: process.env.GITHUB_ID ?? "",
+      clientSecret: process.env.GITHUB_SECRET ?? "",
     }),
   ],
   pages: {
     signIn: '/auth/signin',
   },
-})
+  callbacks: {
+    async signIn({ user, account, profile, email, credentials }) {
+      if (!process.env.GITHUB_ID || !process.env.GITHUB_SECRET) {
+        console.warn("GitHub OAuth credentials are missing. Authentication will not work.");
+        return false;
+      }
+      return true;
+    },
+  },
+}
+
+const handler = NextAuth(authOptions)
 
 export { handler as GET, handler as POST }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,27 +1,23 @@
-import NextAuth, { NextAuthOptions } from "next-auth"
+import NextAuth from "next-auth"
 import GithubProvider from "next-auth/providers/github"
 
-const authOptions: NextAuthOptions = {
+const githubId = process.env.GITHUB_ID
+const githubSecret = process.env.GITHUB_SECRET
+
+if (!githubId || !githubSecret) {
+  console.warn('Missing GitHub OAuth credentials. Authentication will be disabled.');
+}
+
+const handler = NextAuth({
   providers: [
     GithubProvider({
-      clientId: process.env.GITHUB_ID ?? "",
-      clientSecret: process.env.GITHUB_SECRET ?? "",
+      clientId: githubId ?? "",
+      clientSecret: githubSecret ?? "",
     }),
   ],
   pages: {
     signIn: '/auth/signin',
   },
-  callbacks: {
-    async signIn({ user, account, profile, email, credentials }) {
-      if (!process.env.GITHUB_ID || !process.env.GITHUB_SECRET) {
-        console.warn("GitHub OAuth credentials are missing. Authentication will not work.");
-        return false;
-      }
-      return true;
-    },
-  },
-}
-
-const handler = NextAuth(authOptions)
+})
 
 export { handler as GET, handler as POST }


### PR DESCRIPTION
This PR addresses the CI build failure due to missing GitHub OAuth credentials.

Changes made:
- Updated NextAuth configuration to handle missing credentials gracefully
- Modified CI workflow to include necessary environment variables

These changes allow the build process to complete even when OAuth credentials are not provided, which is often the case in CI environments. In a real authentication scenario, the sign-in process will still fail if credentials are missing, but it won't prevent the application from building.